### PR TITLE
Fix bug where unmatched SN names were still being added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.DS_Store
 sne-external-WISEREP
 sne-internal
 __pycache__
 *.pyc
+*.swp

--- a/wisewebspider/main.py
+++ b/wisewebspider/main.py
@@ -294,6 +294,7 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
             attrs={"style": "color:darkred; font-size:small"})
 
         # parse obj_list, match to SNname, and find its spectra
+        target = ''
         for obj in obj_list:
             obj_header = obj.parent.findChildren("td")
             obj_name = obj_header[obj_name_idx].text
@@ -326,6 +327,9 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
                                     ' has no spectra to collect' + '\n')
                             f.close()
                         continue
+        # No match found, skip this event
+        if not target:
+            continue
 
         # exclude non-SN
         SNtype = target[type_idx].text

--- a/wisewebspider/main.py
+++ b/wisewebspider/main.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-
 """
 ===============================================================================
 title           :main.py for wisewebspider package
@@ -43,41 +42,16 @@ _WISEREP_SPECTRA_URL = 'http://wiserep.weizmann.ac.il/spectra/list'
 
 # list of non-supernovae to exclude
 exclude_type = [
-    'Afterglow',
-    'LBV',
-    'ILRT',
-    'Nova',
-    'CV',
-    'Varstar',
-    'AGN',
-    'Galaxy',
-    'QSO',
-    'Std-spec',
-    'Gap',
-    'Gap I',
-    'Gap II',
-    'SN impostor',
-    'TDE',
-    'WR',
-    'WR-WN',
-    'WR-WC',
-    'WR-WO',
-    'Other'
+    'Afterglow', 'LBV', 'ILRT', 'Nova', 'CV', 'Varstar', 'AGN', 'Galaxy',
+    'QSO', 'Std-spec', 'Gap', 'Gap I', 'Gap II', 'SN impostor', 'TDE', 'WR',
+    'WR-WN', 'WR-WC', 'WR-WO', 'Other'
 ]
 
 # list of SN survey programs to exclude, assuming they have already been
 # collected
 exclude_program = [
-    'HIRES',
-    'SUSPECT',
-    'BSNIP',
-    'CSP',
-    'UCB-SNDB',
-    'CfA-Ia',
-    'CfA-Ibc',
-    'CfA-Stripped',
-    'SNfactory',
-    'HIRES'
+    'HIRES', 'SUSPECT', 'BSNIP', 'CSP', 'UCB-SNDB', 'CfA-Ia', 'CfA-Ibc',
+    'CfA-Stripped', 'SNfactory', 'HIRES'
 ]
 
 
@@ -100,19 +74,32 @@ def updateListsJson(SNname, dict_list, list_dict, path):
 
 
 def main():
-    parser = argparse.ArgumentParser(prog='wisewebspider',
-                                     description='WISeWEBspider')
-    parser.add_argument('--update', '-u', dest='update',
-                        help='Run spider in update mode',
-                        default=False, action='store_true')
-    parser.add_argument('--daysago', '-d', dest='daysago',
-                        help='Number of days since last update.' +
-                        'Set to 1, 2, 7, 14, 30, 180, or 365.',
-                        default=False, action='store')
-    parser.add_argument('--path', '-p', dest='path',
-                        help='Path to sne-external-WISEREP directory. ' +
-                        'Default: Within main WISeWEBSpider directory.',
-                        default=_DIR_WISEREP, type=str, action='store')
+    parser = argparse.ArgumentParser(
+        prog='wisewebspider', description='WISeWEBspider')
+    parser.add_argument(
+        '--update',
+        '-u',
+        dest='update',
+        help='Run spider in update mode',
+        default=False,
+        action='store_true')
+    parser.add_argument(
+        '--daysago',
+        '-d',
+        dest='daysago',
+        help='Number of days since last update.' +
+        'Set to 1, 2, 7, 14, 30, 180, or 365.',
+        default=False,
+        action='store')
+    parser.add_argument(
+        '--path',
+        '-p',
+        dest='path',
+        help='Path to sne-external-WISEREP directory. ' +
+        'Default: Within main WISeWEBSpider directory.',
+        default=_DIR_WISEREP,
+        type=str,
+        action='store')
     args = parser.parse_args()
 
     spider(update=args.update, daysago=args.daysago, path=args.path)
@@ -130,10 +117,7 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
         with open(_PATH + path + 'lists.json', 'r') as json_in:
             list_dict = json.load(json_in)
     else:
-        list_dict = {
-            'non_SN': [],
-            'completed': []
-        }
+        list_dict = {'non_SN': [], 'completed': []}
 
         with open(_PATH + path + 'lists.json', 'w') as fp:
             json.dump(list_dict, fp, indent=4)
@@ -144,7 +128,7 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
     browser = RoboBrowser(history=True, parser='lxml')
     browser.open(_WISEREP_SPECTRA_URL)
     form = browser.get_form(action='/spectra/list')
-    form['spectypeid'] = "2"           # 2 for Host spectrum
+    form['spectypeid'] = "2"  # 2 for Host spectrum
     form['rowslimit'] = "10000"
     browser.submit_form(form)
     print('\tHost page received')
@@ -169,10 +153,11 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
         if header.text == 'Ascii FileFits  File':
             host_filename_idx = i
 
-    obj_host_list = browser.find_all("a", {"title": "Click to show/update object"})
+    obj_host_list = browser.find_all("a",
+                                     {"title": "Click to show/update object"})
 
     for i, obj in enumerate(obj_host_list):
-        print('\tParsing', i+1, 'of', len(obj_host_list), 'host spectra')
+        print('\tParsing', i + 1, 'of', len(obj_host_list), 'host spectra')
         obj_name = obj.text
         host_children = obj.parent.parent.findChildren("td")
         host_program = host_children[host_program_idx].text
@@ -228,8 +213,8 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
     elif browser and not update:
         # grab object name list, and remove `Select Option' from list [1:]
         print('Grabbing list of events from WISeREP')
-        SN_list_tags = browser.find(
-            "select", {"name": "objid"}).find_all("option")[1:]
+        SN_list_tags = browser.find("select",
+                                    {"name": "objid"}).find_all("option")[1:]
 
     # Begin by selecting event, visiting page, and scraping.
     for item in SN_list_tags:
@@ -263,11 +248,13 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
                 "tr", {"style": "font-weight:bold"}).findChildren("td")
         except AttributeError:
             if update:
-                updateListsJson(SNname, list_dict['completed'], list_dict, path)
+                updateListsJson(SNname, list_dict['completed'], list_dict,
+                                path)
                 print('\t', 'No spectra to collect')
                 break
             else:
-                updateListsJson(SNname, list_dict['completed'], list_dict, path)
+                updateListsJson(SNname, list_dict['completed'], list_dict,
+                                path)
                 print('\t', SNname, 'has no available spectra')
                 with open(_PATH + path + 'scraper-log.txt', 'a') as f:
                     f.write('From statement 1: ' + SNname +
@@ -295,13 +282,16 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
             print('\tNew data available for', num_objs, 'objects.')
         if num_objs != 1:
             with open(_PATH + path + 'scraper-log.txt', 'a') as f:
-                f.write(str(num_objs) + ' objects returned for ' + SNname + '\n')
+                f.write(
+                    str(num_objs) + ' objects returned for ' + SNname + '\n')
                 f.close()
 
         # locate darkred text ``Potential matching IAU-Name'' if it exists
         # the location of html table rows (tr) changes if it exists
-        darkred = browser.find("span", text=" Potential matching IAU-Name/s:",
-                               attrs={"style": "color:darkred; font-size:small"})
+        darkred = browser.find(
+            "span",
+            text=" Potential matching IAU-Name/s:",
+            attrs={"style": "color:darkred; font-size:small"})
 
         # parse obj_list, match to SNname, and find its spectra
         for obj in obj_list:
@@ -314,12 +304,12 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
                 # this checks for spurious page element that changes layout
                 if darkred:
                     try:
-                        target_spectra = (obj.parent.nextSibling.nextSibling
-                                          .findChildren("tr", {"valign": "top"}))
+                        target_spectra = (
+                            obj.parent.nextSibling.nextSibling.findChildren(
+                                "tr", {"valign": "top"}))
                     except AttributeError:
                         print('\t', SNname, 'has no spectra to collect')
-                        with open(_PATH + path +
-                                  'scraper-log.txt', 'a') as f:
+                        with open(_PATH + path + 'scraper-log.txt', 'a') as f:
                             f.write('From statement 2: ' + SNname +
                                     ' has no spectra to collect' + '\n')
                             f.close()
@@ -331,8 +321,7 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
                             "tr", {"valign": "top"})
                     except AttributeError:
                         print('\t', SNname, 'has no spectra to collect')
-                        with open(_PATH + path +
-                                  'scraper-log.txt', 'a') as f:
+                        with open(_PATH + path + 'scraper-log.txt', 'a') as f:
                             f.write('From statement 3: ' + SNname +
                                     ' has no spectra to collect' + '\n')
                             f.close()
@@ -384,7 +373,8 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
         num_pub_spectra = 0
 
         spec_header = browser.find(
-            "tr", {"style": "color:black; font-size:x-small"}).findChildren("td")
+            "tr",
+            {"style": "color:black; font-size:x-small"}).findChildren("td")
         for i, header in enumerate(spec_header):
             if header.text == 'Spec. Prog.':
                 program_idx = i
@@ -434,25 +424,9 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
             # list of duplicate file prefixes to be excluded
             # list not shorted to ['t', 'f', 'PHASE'] for sanity
             regexes = [
-                't' + SNname,
-                'tPSN',
-                'tPS',
-                'tLSQ',
-                'tGaia',
-                'tATLAS',
-                'tASASSN',
-                'tSMT',
-                'tCATA',
-                'tSNhunt',
-                'tSNHunt',
-                'fSNhunt',
-                'tSNHiTS',
-                'tCSS',
-                'tSSS',
-                'tCHASE',
-                'tSN',
-                'tAT',
-                'fPSN',
+                't' + SNname, 'tPSN', 'tPS', 'tLSQ', 'tGaia', 'tATLAS',
+                'tASASSN', 'tSMT', 'tCATA', 'tSNhunt', 'tSNHunt', 'fSNhunt',
+                'tSNHiTS', 'tCSS', 'tSSS', 'tCHASE', 'tSN', 'tAT', 'fPSN',
                 'PHASE'
             ]
 
@@ -472,25 +446,20 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
             contrib = children[contrib_idx].text
             bibcode = children[publish_idx].text
             bibcode = unicodedata.normalize("NFKD", bibcode)
-            if contrib == 'Ruiz-Lapuente, et al. 1997, Thermonuclear Supernovae. Dordrecht: Kluwer':
+            if (contrib == ('Ruiz-Lapuente, et al. 1997, Thermonuclear '
+                            'Supernovae. Dordrecht: Kluwer')):
                 bibcode = '1997Obs...117..312R'
                 contrib = 'Ruiz-Lapuente et al. 1997'
             elif '%26' in bibcode:
                 bibcode = bibcode.replace('%26', '&')
 
             SN_dict[SNname][filename] = OrderedDict([
-                ("Type", SNtype),
-                ("Redshift", redshift),
-                ("Obs. Date", obsdate),
-                ("Program", program),
-                ("Contributor", contrib),
-                ("Bibcode", bibcode),
-                ("Instrument", instrument),
-                ("Observer", observer),
-                ("Reducer", reducer),
-                ("Reduction Status", status),
-                ("Last Modified", last_modified),
-                ("Modified By", modified_by)
+                ("Type", SNtype), ("Redshift", redshift),
+                ("Obs. Date", obsdate), ("Program", program),
+                ("Contributor", contrib), ("Bibcode", bibcode),
+                ("Instrument", instrument), ("Observer", observer),
+                ("Reducer", reducer), ("Reduction Status", status),
+                ("Last Modified", last_modified), ("Modified By", modified_by)
             ])
 
             spectrum_haul[filename] = dat_url
@@ -525,8 +494,8 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
         if len(spectrum_haul) == 0:
             print('\tNot collecting spectra at this time')
             with open(_PATH + path + 'scraper-log.txt', 'a') as f:
-                f.write('Not collecting spectra of ' +
-                        SNname + ' at this time' + '\n')
+                f.write('Not collecting spectra of ' + SNname + ' at this time'
+                        + '\n')
                 f.close()
 
             with open(_PATH + path + SNname + '/README.json', 'w') as fp:
@@ -548,11 +517,12 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
 
                 print('\tNot collecting spectra at this time')
                 with open(_PATH + path + 'scraper-log.txt', 'a') as f:
-                    f.write('Not collecting spectra of ' +
-                            SNname + ' at this time' + '\n')
+                    f.write('Not collecting spectra of ' + SNname +
+                            ' at this time' + '\n')
                     f.close()
 
-                updateListsJson(SNname, list_dict['completed'], list_dict, path)
+                updateListsJson(SNname, list_dict['completed'], list_dict,
+                                path)
                 continue
 
             print('\tDownloading 1 public spectrum')
@@ -564,8 +534,7 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
             for filename, url in spectrum_haul.items():
                 rq = Request(url)
                 res = urlopen(rq)
-                dat = open(_PATH + path +
-                           SNname + "/" + filename, 'wb')
+                dat = open(_PATH + path + SNname + "/" + filename, 'wb')
                 dat.write(res.read())
                 dat.close()
 
@@ -590,11 +559,11 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
                     del SN_dict[SNname][filename]
                     del spectrum_haul[filename]
 
-                    print('\tRemoving duplicate spectrum for',
-                          SNname, '--', filename)
+                    print('\tRemoving duplicate spectrum for', SNname, '--',
+                          filename)
                     with open(_PATH + path + 'scraper-log.txt', 'a') as f:
-                        f.write('Removing duplicate spectrum for ' +
-                                SNname + ' -- ' + filename + '\n')
+                        f.write('Removing duplicate spectrum for ' + SNname +
+                                ' -- ' + filename + '\n')
                         f.close()
 
             # remove host spectrum if it exists
@@ -609,10 +578,11 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
             if len(SN_dict[SNname].keys()) == 0:
                 print('\tNot collecting spectra at this time')
                 with open(_PATH + path + 'scraper-log.txt', 'a') as f:
-                    f.write('Not collecting spectra of ' +
-                            SNname + ' at this time' + '\n')
+                    f.write('Not collecting spectra of ' + SNname +
+                            ' at this time' + '\n')
                     f.close()
-                updateListsJson(SNname, list_dict['completed'], list_dict, path)
+                updateListsJson(SNname, list_dict['completed'], list_dict,
+                                path)
                 continue
 
             last_modified = {}
@@ -636,10 +606,11 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
                         last_modified[k] = newdate
 
             if len(last_modified) <= 1:
-                print('\tPresumably no other duplicate files found for', SNname)
+                print('\tPresumably no other duplicate files found for',
+                      SNname)
                 with open(_PATH + path + 'scraper-log.txt', 'a') as f:
-                    f.write(
-                        'Presumably no other duplicate files found for ' + SNname + '\n')
+                    f.write('Presumably no other duplicate files found for ' +
+                            SNname + '\n')
                     f.close()
 
             elif len(last_modified) == 2:
@@ -647,22 +618,21 @@ def spider(update=False, daysago=30, path=_DIR_WISEREP):
                 del SN_dict[SNname][duplicate]
                 del spectrum_haul[duplicate]
 
-                print('\tRemoving duplicate spectrum for',
-                      SNname, '--', duplicate)
+                print('\tRemoving duplicate spectrum for', SNname, '--',
+                      duplicate)
                 with open(_PATH + path + 'scraper-log.txt', 'a') as f:
-                    f.write('Removing duplicate spectrum for ' +
-                            SNname + ' -- ' + duplicate + '\n')
+                    f.write('Removing duplicate spectrum for ' + SNname +
+                            ' -- ' + duplicate + '\n')
                     f.close()
 
             count = 1
             for filename, url in spectrum_haul.items():
-                print('\tDownloading', count, 'of', len(
-                    SN_dict[SNname]), 'public spectra')
+                print('\tDownloading', count, 'of', len(SN_dict[SNname]),
+                      'public spectra')
 
                 rq = Request(url)
                 res = urlopen(rq)
-                dat = open(_PATH + path +
-                           SNname + "/" + filename, 'wb')
+                dat = open(_PATH + path + SNname + "/" + filename, 'wb')
                 dat.write(res.read())
                 dat.close()
 


### PR DESCRIPTION
The `target` variable was being set in a loop if `SNName` matched an object name on a page, but if there were no matches the `target` variable's previous value, from the last matched supernova, was used instead. This likely was causing unmatched SNs to be added with data from the previous SN.

A full rebuild is likely necessary after this change as we need to remove many erroneous entries from `sne-external-WISEREP`.
